### PR TITLE
Add reset button to clear calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
           <button id="exportData" class="btn">Export Data</button>
           <button id="importData" class="btn">Import Data</button>
           <button id="exportPdf" class="btn">Export to PDF</button>
+          <button id="resetCalendar" class="btn">Reset</button>
           <input type="file" id="importFile" accept=".json" style="display: none;">
         </div>
       </div>

--- a/js/app.js
+++ b/js/app.js
@@ -681,8 +681,8 @@ export class YearPlannerApp {
       if (!confirmed) return;
 
       // Show second confirmation dialog
-      const secondConfirmed = confirm('This action cannot be undone. Type "Yes, I understand" to confirm.');
-      if (secondConfirmed !== 'Yes, I understand') return;
+      const secondConfirmation = prompt('This action cannot be undone. Type "Yes, I understand" to confirm.');
+      if (secondConfirmation !== 'Yes, I understand') return;
 
       // Clear all data
       await this.storageAdapter.clearAllData();

--- a/js/app.js
+++ b/js/app.js
@@ -236,6 +236,7 @@ export class YearPlannerApp {
     const importBtn = document.getElementById('importData');
     const exportPdfBtn = document.getElementById('exportPdf');
     const importFile = document.getElementById('importFile');
+    const resetBtn = document.getElementById('resetCalendar');
 
     if (exportBtn) {
       exportBtn.addEventListener('click', () => this.exportData());
@@ -251,6 +252,10 @@ export class YearPlannerApp {
 
     if (importFile) {
       importFile.addEventListener('change', (e) => this.handleImportFile(e));
+    }
+
+    if (resetBtn) {
+      resetBtn.addEventListener('click', () => this.handleResetCalendar());
     }
 
     // New event button
@@ -348,6 +353,11 @@ export class YearPlannerApp {
     exportPdfBtn.textContent = 'Export to PDF';
     exportPdfBtn.style.padding = '5px 10px';
 
+    const resetBtn = document.createElement('button');
+    resetBtn.id = 'resetCalendar';
+    resetBtn.textContent = 'Reset';
+    resetBtn.style.padding = '5px 10px';
+
     const importFile = document.createElement('input');
     importFile.id = 'importFile';
     importFile.type = 'file';
@@ -358,6 +368,7 @@ export class YearPlannerApp {
     actionButtons.appendChild(exportBtn);
     actionButtons.appendChild(importBtn);
     actionButtons.appendChild(exportPdfBtn);
+    actionButtons.appendChild(resetBtn);
     actionButtons.appendChild(importFile);
 
     // Append everything to controls container
@@ -657,6 +668,32 @@ export class YearPlannerApp {
     } catch (error) {
       console.error('Error deleting event:', error);
       this.displayErrorMessage(`Failed to delete event: ${error.message}`);
+    }
+  }
+
+  /**
+   * Handle resetting the calendar
+   */
+  async handleResetCalendar() {
+    try {
+      // Show confirmation dialog
+      const confirmed = confirm('Are you sure you want to reset the calendar? This will delete all events.');
+      if (!confirmed) return;
+
+      // Show second confirmation dialog
+      const secondConfirmed = confirm('This action cannot be undone. Type "Yes, I understand" to confirm.');
+      if (secondConfirmed !== 'Yes, I understand') return;
+
+      // Clear all data
+      await this.storageAdapter.clearAllData();
+
+      // Reload the year to reflect changes
+      await this.loadYear(this.currentYear);
+
+      this.displaySuccessMessage('Calendar reset successfully');
+    } catch (error) {
+      console.error('Error resetting calendar:', error);
+      this.displayErrorMessage(`Failed to reset calendar: ${error.message}`);
     }
   }
 

--- a/js/components/EventEditorModal.js
+++ b/js/components/EventEditorModal.js
@@ -294,7 +294,7 @@ class EventEditorModal extends HTMLElement {
   }
 
   handleDelete() {
-    this.showConfirmationDialog('Are you sure you want to delete this event?', () => {
+    if (confirm('Are you sure you want to delete this event?')) {
       const deleteEvent = new CustomEvent('event-delete', {
         detail: { eventId: this.event.id },
         bubbles: true,
@@ -303,7 +303,7 @@ class EventEditorModal extends HTMLElement {
 
       this.dispatchEvent(deleteEvent);
       this.close();
-    });
+    }
   }
 
   showConfirmationDialog(message, onConfirm) {

--- a/js/components/EventEditorModal.js
+++ b/js/components/EventEditorModal.js
@@ -294,7 +294,7 @@ class EventEditorModal extends HTMLElement {
   }
 
   handleDelete() {
-    if (confirm('Are you sure you want to delete this event?')) {
+    this.showConfirmationDialog('Are you sure you want to delete this event?', () => {
       const deleteEvent = new CustomEvent('event-delete', {
         detail: { eventId: this.event.id },
         bubbles: true,
@@ -303,6 +303,16 @@ class EventEditorModal extends HTMLElement {
 
       this.dispatchEvent(deleteEvent);
       this.close();
+    });
+  }
+
+  showConfirmationDialog(message, onConfirm) {
+    const confirmation = confirm(message);
+    if (confirmation) {
+      const secondConfirmation = prompt('Type "Yes, I understand" to confirm.');
+      if (secondConfirmation === 'Yes, I understand') {
+        onConfirm();
+      }
     }
   }
 

--- a/js/infrastructure/StorageAdapter.js
+++ b/js/infrastructure/StorageAdapter.js
@@ -224,6 +224,27 @@ class StorageAdapter {
       return value;
     });
   }
+
+  /**
+   * Clear all events from local storage
+   * @returns {boolean} Success status
+   */
+  clearAllData() {
+    try {
+      const keys = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key && key.startsWith(this.namespace)) {
+          keys.push(key);
+        }
+      }
+      keys.forEach((key) => localStorage.removeItem(key));
+      return true;
+    } catch (error) {
+      console.error('Failed to clear all data:', error);
+      return false;
+    }
+  }
 }
 
 // Domain models for reference (would typically be imported)


### PR DESCRIPTION
Fixes #5

Add a "Reset" button to clear the calendar of all events with confirmation dialogs.

* **index.html**
  - Add a "Reset" button within the `import-export-group` div with `id="resetCalendar"`.

* **js/app.js**
  - Add an event listener for the "Reset" button in the `setupEventListeners` method.
  - Implement a `handleResetCalendar` method to clear all events and show confirmation dialogs.
  - Call the `clearAllData` method from `StorageAdapter` in the `handleResetCalendar` method.

* **js/components/EventEditorModal.js**
  - Add a `showConfirmationDialog` method to display a confirmation dialog with "Yes, I understand".
  - Use the `showConfirmationDialog` method in the `handleDelete` method for deleting all events.

* **js/infrastructure/StorageAdapter.js**
  - Add a `clearAllData` method to clear all events from local storage.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Ceesaxp/yaag-calendar/pull/11?shareId=ea76045f-ceca-4711-b4b8-014162a6dfb4).